### PR TITLE
 #29: Schedule automatic builds

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -1,6 +1,8 @@
 name: CMake on multiple platforms
 
 on:
+  schedule:
+    - cron: '0 6 * * 1,4'  
   workflow_dispatch:
   push:
     branches: ["main"]


### PR DESCRIPTION
The linux build is scheduled on Monday and Friday every week so that the conan cache held is not deleted (GitHub automatically deletes it after 7 days of inactivity)